### PR TITLE
Use module instead of jsnext:main

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.2",
   "description": "React component that renders a SVG arrow. Can point in any direction, different styles.",
   "main": "index.js",
-  "jsnext:main": "index.es.js",
+  "module": "index.es.js",
   "repository": "https://github.com/miracle2k/react-arrow.git",
   "author": "Michael Elsdörfer <michael@elsdoerfer.com>",
   "license": "MIT",


### PR DESCRIPTION
As per discussion in https://github.com/rollup/rollup/issues/969

Not sure if this is the only thing holding back support for Pika CDN, but it's one of them: https://www.pika.dev/search?q=@elsdoerfer/react-arrow

And I suppose it would be good to publish afterwards too.